### PR TITLE
Update serverless-monitoring.md

### DIFF
--- a/doc_source/serverless-monitoring.md
+++ b/doc_source/serverless-monitoring.md
@@ -1,6 +1,8 @@
 # Monitoring for Serverless Clusters<a name="serverless-monitoring"></a>
 
-Amazon MSK integrates with Amazon CloudWatch so that you can collect, view, and analyze metrics for your MSK serverless cluster\. The metrics shown in the following table are available for all serverless clusters\. As these metrics are published as individual data points for each partition in the topic, we recommend viewing them as a 'SUM' statistic to get the topic\-level view\.
+Amazon MSK integrates with Amazon CloudWatch so that you can collect, view, and analyze metrics for your MSK serverless cluster\. The metrics shown in the following table are available for all serverless clusters\. As these metrics are published as individual data points for each partition in the topic, we recommend viewing them as a 'SUM' statistic to get the topic\-level view\. The "PerSec" metrics are correctly represented with a "SUM" statistics for a 1 minute period since they are published at a minutely rate.
+
+For periods that are more than a minute, you should use the CloudWatch Metric Math Expression - ``m1 * 60/PERIOD(m1)``
 
 
 **Metrics available at the DEFAULT monitoring level**  

--- a/doc_source/serverless-monitoring.md
+++ b/doc_source/serverless-monitoring.md
@@ -1,8 +1,10 @@
 # Monitoring for Serverless Clusters<a name="serverless-monitoring"></a>
 
-Amazon MSK integrates with Amazon CloudWatch so that you can collect, view, and analyze metrics for your MSK serverless cluster\. The metrics shown in the following table are available for all serverless clusters\. As these metrics are published as individual data points for each partition in the topic, we recommend viewing them as a 'SUM' statistic to get the topic\-level view\. The "PerSec" metrics are correctly represented with a "SUM" statistics for a 1 minute period since they are published at a minutely rate.
+Amazon MSK integrates with Amazon CloudWatch so that you can collect, view, and analyze metrics for your MSK serverless cluster\. The metrics shown in the following table are available for all serverless clusters\. As these metrics are published as individual data points for each partition in the topic, we recommend viewing them as a 'SUM' statistic to get the topic\-level view\. 
+We publish PerSec metrics for Amazon MSK to CloudWatch at a frequency of once per minute. This means that the 'SUM' statistic for a one-minute period accurately represents per-second data for PerSec metrics.
 
-For periods that are more than a minute, you should use the CloudWatch Metric Math Expression - ``m1 * 60/PERIOD(m1)``
+To collect per-second data for a period of longer than one minute, use the following CloudWatch math expression: 
+``m1 * 60/PERIOD(m1)``
 
 
 **Metrics available at the DEFAULT monitoring level**  


### PR DESCRIPTION
Updating the document to elaborate on the SUM statistics and metric math to be used for a period that is more than a minute.

*Issue #, if available:*

*Description of changes:* Updated the documentation for the "PerSec" metrics to reflect correctly for more than 1 minute period. Also, highlighted that the metrics are correctly represented when per minute is used with statistics SUM.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
